### PR TITLE
More fixes to Binary Tree Search

### DIFF
--- a/src/SearchAlgorithms.Core/Algorithms/BinarySearch.cs
+++ b/src/SearchAlgorithms.Core/Algorithms/BinarySearch.cs
@@ -5,7 +5,7 @@ using SearchAlgorithms.Core.Utils;
 
 namespace SearchAlgorithms.Core.Algorithms
 {
-    // Note: this algorithm (partially) works only for strings with characters in alphabetical order
+    // Note: this algorithm works only with longString in alphabetical order and with one-character lookingString
     public class BinarySearch : ISearchAlgorithm
     {
         public string Name()
@@ -15,13 +15,14 @@ namespace SearchAlgorithms.Core.Algorithms
 
         public List<int> Search(in string lookingString, in string longString)
         {
-            string needle = string.Concat(lookingString.OrderBy(c => c));
+            string needle = lookingString[0].ToString();
+            string haystack = longString.SortCharacters();
 
             var continueExecution = true;
             var result = new List<int>();
             var tree = new BinaryTree();
 
-            Array.ForEach(longString.ToCharArray(), tree.Insert);
+            Array.ForEach(haystack.ToCharArray(), tree.Insert);
             var currentNode = tree.RootNode;
 
             int analysedIndex = 0;
@@ -39,7 +40,7 @@ namespace SearchAlgorithms.Core.Algorithms
 
                 if (analysedIndex == needle.Length)
                 {
-                    result.Add(currentNode.ElemNumber);
+                    result.Add(currentNode.ElemNumber );
                     analysedIndex = 0;
                 }
 

--- a/src/SearchAlgorithms.Core/Program.cs
+++ b/src/SearchAlgorithms.Core/Program.cs
@@ -1,7 +1,9 @@
 ﻿using SearchAlgorithms.Core.Algorithms;
 using System;
 using System.Collections.Generic;
+using SearchAlgorithms.Core.Utils;
 using SearchAlgorithms.Core.Testing.Validators;
+using System.Security.Cryptography;
 
 namespace SearchAlgorithms.Core
 {
@@ -9,25 +11,34 @@ namespace SearchAlgorithms.Core
     {
         static void Main(string[] args)
         {
-            var currentlyCheckedAlgorithm = new KMPSearch();
+            var currentlyCheckedAlgorithm = new BinarySearch();
+            var correctlyWorkingAlgorithm = new BuiltInSearch();
 
-            Console.WriteLine("Zaraz powinno wyświetlić się True, jeśli algorytm działa poprawnie.");
-            Console.WriteLine("Jeśli algorytm działa niepoprawnie, wyświetli się False.");
-            var validationResult = new SearchAlgorithmValidator(currentlyCheckedAlgorithm).Validate();
-            Console.WriteLine(validationResult);
+            string haystack = GetRandomString(1000).SortCharacters();
+            string needle = haystack[new Random().Next(0, haystack.Length - 1)].ToString().SortCharacters();
 
+            Console.WriteLine(haystack);
+            Console.WriteLine(needle);
 
-            var searchResult = currentlyCheckedAlgorithm.Search("bb", "aabbaabb");
-            var correctResult = new BuiltInSearch().Search("bb", "aabbaabb");
-
-            Console.WriteLine("\nWyszukuję napis bb w napisie aabbaabb");
-            Console.WriteLine("Poprawnie działający algorytm zwrócił takie dane: ");
-            Console.WriteLine(string.Join(" ", correctResult));
-            Console.WriteLine("Twój algorytm zwrócił takie dane: ");
-            Console.WriteLine(string.Join(" ", searchResult));
+            Console.WriteLine(currentlyCheckedAlgorithm.Name());
+            Array.ForEach(currentlyCheckedAlgorithm.Search(needle, haystack).ToArray(), Console.WriteLine);
+            Console.WriteLine(correctlyWorkingAlgorithm.Name());
+            Array.ForEach(correctlyWorkingAlgorithm.Search(needle, haystack).ToArray(), Console.WriteLine);
 
 
             Console.ReadKey();
+        }
+
+        static string GetRandomString(int string_length)
+        {
+            using (var rng = new RNGCryptoServiceProvider())
+            {
+                var bit_count = (string_length * 6);
+                var byte_count = ((bit_count + 7) / 8);
+                var bytes = new byte[byte_count];
+                rng.GetBytes(bytes);
+                return Convert.ToBase64String(bytes);
+            }
         }
     }
 }

--- a/src/SearchAlgorithms.Core/SearchAlgorithms.Core.csproj
+++ b/src/SearchAlgorithms.Core/SearchAlgorithms.Core.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Algorithms\BinarySearch.cs" />
     <Compile Include="Algorithms\BoyerMooreSearch.cs" />
     <Compile Include="Algorithms\HashSearch.cs" />
     <Compile Include="Algorithms\ISearchAlgorithm.cs" />
@@ -64,7 +65,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Algorithms\TestSearch.cs" />
     <Compile Include="Testing\Validators\SearchAlgorithmValidator.cs" />
+    <Compile Include="Utils\BinaryTree.cs" />
     <Compile Include="Utils\PrimeNumberUtils.cs" />
+    <Compile Include="Utils\StringSort.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/SearchAlgorithms.Core/Utils/StringSort.cs
+++ b/src/SearchAlgorithms.Core/Utils/StringSort.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SearchAlgorithms.Core.Utils
+{
+    public static class StringSort
+    {
+        public static string SortCharacters(this string str)
+        {
+            char[] characters = str.ToArray();
+            Array.Sort(characters);
+            return new string(characters);
+        }
+    }
+}


### PR DESCRIPTION
Another attempt to repair the binary tree search algorithm
Now the algorithm should work correctly for a long string with characters sorted in alphabetical order and a short string consisting of only one character.